### PR TITLE
clone時のオプションに --no-single-branch をつける

### DIFF
--- a/models/project/project.go
+++ b/models/project/project.go
@@ -77,7 +77,7 @@ func Full(name string) (*Project, error) {
 
 // Clone runs `git clone` for project repo
 func Clone(url string) (*Project, error) {
-	cmd := exec.Command("git", "clone", url, "--depth", "20") // TODO: make it configurable
+	cmd := exec.Command("git", "clone", url, "--depth", "20", "--no-single-branch") // TODO: make it configurable
 	cmd.Dir = workdir.ProjectsDir()
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
`--depth` オプションをつけると新し目のgitではデフォルトで `--single-branch` オプションがついてしまって、cloneしてきたブランチ以外にcheckoutすることができなくなるので、`--no-single-branch` オプションを付けたいです