### PR TITLE
Performance turning for default branch

### DIFF
--- a/models/cache/default_branch_cache.go
+++ b/models/cache/default_branch_cache.go
@@ -18,7 +18,7 @@ func SetDefaultBranch(project string, branch string) {
 	defaultBranchCache[project] = branch
 }
 
-// Delete default branch in cache
+// DeleteDefaultBranch deletes the default branch cache entry.
 func DeleteDefaultBranch(project string) {
 	delete(defaultBranchCache, project)
 }

--- a/models/cache/default_branch_cache.go
+++ b/models/cache/default_branch_cache.go
@@ -13,7 +13,7 @@ func GetDefaultBranch(project string) string {
 	return branch
 }
 
-// Set default branch to cache
+// SetDefaultBranch caches the default branch name.
 func SetDefaultBranch(project string, branch string) {
 	defaultBranchCache[project] = branch
 }

--- a/models/cache/default_branch_cache.go
+++ b/models/cache/default_branch_cache.go
@@ -1,0 +1,19 @@
+package cache
+
+var defaultBranchCache = make(map[string]string)
+
+// Get cached default branch
+func GetDefaultBranch(project string) string {
+	branch, ok := defaultBranchCache[project]
+
+	if !ok {
+		return ""
+	}
+
+	return branch
+}
+
+// Set default branch to cache
+func SetDefaultBranch(project string, branch string) {
+	defaultBranchCache[project] = branch
+}

--- a/models/cache/default_branch_cache.go
+++ b/models/cache/default_branch_cache.go
@@ -1,24 +1,31 @@
 package cache
 
-var defaultBranchCache = make(map[string]string)
+import "sync"
 
-// GetDefaultBranch returns the default branch name in cache.
-func GetDefaultBranch(project string) string {
-	branch, ok := defaultBranchCache[project]
+type defaultBranchCache struct {
+	sm sync.Map
+}
+
+// DefaultBranch represents cache of default branch
+var DefaultBranch = &defaultBranchCache{}
+
+// Load returns the default branch name in cache.
+func (c *defaultBranchCache) Load(project string) string {
+	branch, ok := c.sm.Load(project)
 
 	if !ok {
 		return ""
 	}
 
-	return branch
+	return branch.(string)
 }
 
-// SetDefaultBranch caches the default branch name.
-func SetDefaultBranch(project string, branch string) {
-	defaultBranchCache[project] = branch
+// Store caches the default branch name.
+func (c *defaultBranchCache) Store(project string, branch string) {
+	c.sm.Store(project, branch)
 }
 
-// DeleteDefaultBranch deletes the default branch cache entry.
-func DeleteDefaultBranch(project string) {
-	delete(defaultBranchCache, project)
+// Delete deletes the default branch cache entry.
+func (c *defaultBranchCache) Delete(project string) {
+	c.sm.Delete(project)
 }

--- a/models/cache/default_branch_cache.go
+++ b/models/cache/default_branch_cache.go
@@ -2,7 +2,7 @@ package cache
 
 var defaultBranchCache = make(map[string]string)
 
-// Get cached default branch
+// GetDefaultBranch returns the default branch name in cache.
 func GetDefaultBranch(project string) string {
 	branch, ok := defaultBranchCache[project]
 

--- a/models/cache/default_branch_cache.go
+++ b/models/cache/default_branch_cache.go
@@ -17,3 +17,8 @@ func GetDefaultBranch(project string) string {
 func SetDefaultBranch(project string, branch string) {
 	defaultBranchCache[project] = branch
 }
+
+// Delete default branch in cache
+func DeleteDefaultBranch(project string) {
+	delete(defaultBranchCache, project)
+}

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -244,7 +244,7 @@ func (p *Project) GetDefaultBranch() (string, error) {
 // GetCachedDefaultBranch returns cached default branch if exists.
 // GetCachedDefaultBranch returns the default branch from memory if cached, otherwise, compute and cache it.
 func (p *Project) GetCachedDefaultBranch() (string, error) {
-	cachedDefaultBranch := cache.GetDefaultBranch(p.Name)
+	cachedDefaultBranch := cache.DefaultBranch.Load(p.Name)
 
 	if cachedDefaultBranch != "" {
 		// returns cached default branch
@@ -257,7 +257,7 @@ func (p *Project) GetCachedDefaultBranch() (string, error) {
 		return "", err
 	}
 
-	cache.SetDefaultBranch(p.Name, defaultBranch)
+	cache.DefaultBranch.Store(p.Name, defaultBranch)
 
 	return defaultBranch, nil
 }

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -241,7 +241,7 @@ func (p *Project) GetDefaultBranch() (string, error) {
 	return group[1], nil
 }
 
-// Returns cached default branch if exists.
+// GetCachedDefaultBranch returns cached default branch if exists.
 // If default branch is not cached, get default branch from and save to cache.
 func (p *Project) GetCachedDefaultBranch() (string, error) {
 	cachedDefaultBranch := cache.GetDefaultBranch(p.Name)

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -242,7 +242,7 @@ func (p *Project) GetDefaultBranch() (string, error) {
 }
 
 // GetCachedDefaultBranch returns cached default branch if exists.
-// If default branch is not cached, get default branch from and save to cache.
+// GetCachedDefaultBranch returns the default branch from memory if cached, otherwise, compute and cache it.
 func (p *Project) GetCachedDefaultBranch() (string, error) {
 	cachedDefaultBranch := cache.GetDefaultBranch(p.Name)
 

--- a/web/server.go
+++ b/web/server.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/edvakf/go-pploy/models/cache"
 	"github.com/edvakf/go-pploy/models/gitutil"
 	"github.com/edvakf/go-pploy/models/ldapusers"
 	"github.com/edvakf/go-pploy/models/locks"
@@ -133,6 +134,12 @@ func postCheckout(c echo.Context) error {
 	r, err := p.Checkout(form.Ref)
 	if err != nil {
 		return c.String(http.StatusOK, err.Error())
+	}
+
+	// Update default branch in cache
+	defaultBranch, err := p.GetDefaultBranch()
+	if err == nil {
+		cache.SetDefaultBranch(p.Name, defaultBranch)
 	}
 
 	return transferEncodingChunked(c, r)

--- a/web/server.go
+++ b/web/server.go
@@ -183,6 +183,8 @@ func postRemove(c echo.Context) error {
 		return c.String(http.StatusOK, err.Error())
 	}
 
+	cache.DeleteDefaultBranch(p.Name)
+
 	return c.Redirect(http.StatusFound, PathPrefix)
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -139,7 +139,7 @@ func postCheckout(c echo.Context) error {
 	// Update default branch in cache
 	defaultBranch, err := p.GetDefaultBranch()
 	if err == nil {
-		cache.SetDefaultBranch(p.Name, defaultBranch)
+		cache.DefaultBranch.Store(p.Name, defaultBranch)
 	}
 
 	return transferEncodingChunked(c, r)
@@ -183,7 +183,7 @@ func postRemove(c echo.Context) error {
 		return c.String(http.StatusOK, err.Error())
 	}
 
-	cache.DeleteDefaultBranch(p.Name)
+	cache.DefaultBranch.Delete(p.Name)
 
 	return c.Redirect(http.StatusFound, PathPrefix)
 }


### PR DESCRIPTION
# Context
592ec167ac598258dc986139b0cca7f84c219fa4 is very slow, because `git remote show` is executed each view rendering :tired_face:

So I add caching

ref #8

# Architecture
* Add default branch cache (in memory)
* Use cache from view rendering
* Update cache after each `git checkout`

# Benchmark at project page
Using Chrome developer tool

![image](https://user-images.githubusercontent.com/608755/58365124-b4b20480-7efa-11e9-963c-bd3c6b284705.png)

## Before (v1.1.4)
* 1,950ms
* 2,440ms
* 1,970ms
* 3,150ms
* 2,040ms

## After (this PR)
* 2,030ms (1st),  2ms (2nd)
* 1,960ms (1st),  5ms (2nd)
* 1,950ms (1st),  2ms (2nd)
* 2,010ms (1st),  2ms (2nd)
* 3,290ms (1st),  2ms (2nd)

### remarks
1st is slow because branch is not cached, but 2nd is fast because branch is cached.

