### PR TITLE
Fixed. pploy can't checkout except master branch

### DIFF
--- a/models/project/project.go
+++ b/models/project/project.go
@@ -86,7 +86,7 @@ func Full(name string) (*Project, error) {
 
 // Clone runs `git clone` for project repo
 func Clone(url string) (*Project, error) {
-	cmd := exec.Command("git", "clone", url, "--depth", "20") // TODO: make it configurable
+	cmd := exec.Command("git", "clone", url, "--depth", "20", "--no-single-branch") // TODO: make it configurable
 	cmd.Dir = workdir.ProjectsDir()
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
`git clone --depth 20` without `--no-single-branch`, pploy can't checkout except master branch

e.g.

```
$ git clone git@github.com:sue445/gitpanda.git --depth 20

$ cat gitpanda/.git/config

[remote "origin"]
	fetch = +refs/heads/master:refs/remotes/origin/master
```

So I add `--no-single-branch`

```
$ git clone git@github.com:sue445/dotfiles.git --depth 20 --no-single-branch

$ cat dotfiles/.git/config
[remote "origin"]
	fetch = +refs/heads/*:refs/remotes/origin/*
```

c.f.

```
$ git clone --help

(snip)

       --depth <depth>
           Create a shallow clone with a history truncated to the specified number of commits. Implies --single-branch unless --no-single-branch is given to fetch the histories near the tips of all branches.
           If you want to clone submodules shallowly, also pass --shallow-submodules.
```