### PR TITLE
DatadogのEventにPostする

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ When tagged, travis uploads binaries to GitHub Release.
 
 ```
 Usage of ./go-pploy:
+  -ddapikey string
+    	Datadog API key
+  -ddappkey string
+    	Datadog APP key
+  -ddlockgained string
+    	Message template for Datadog when lock is gained
+  -ddlockreleased string
+    	Message template for Datadog when lock is released
+  -ddlockextended string
+    	Message template for Datadog when lock is extended
+  -ddlockextended string
+    	Message template for Datadog when deploy is ended
   -deployed string
     	Message template for when deploy is ended
   -ldapdn string

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/edvakf/go-pploy
 go 1.12
 
 require (
+	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/facebookarchive/pidfile v0.0.0-20150612191647-f242e2999868
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 // indirect
 	github.com/facebookgo/pidfile v0.0.0-20150612191647-f242e2999868 // indirect
@@ -21,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
+	github.com/zorkian/go-datadog-api v2.21.0+incompatible
 	golang.org/x/crypto v0.0.0-20180208170933-5119cf507ed5 // indirect
 	golang.org/x/sys v0.0.0-20180202135801-37707fdb30a5 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20170511165959-379148ca0225 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
+github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/facebookarchive/pidfile v0.0.0-20150612191647-f242e2999868 h1:6+BXLwguZv0VHp7T286BKFxkzhn0n/rKBxfD2bBda4U=
@@ -39,6 +41,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
+github.com/zorkian/go-datadog-api v2.21.0+incompatible h1:0VoM99qhHpD3FusaEaeD3C6HikYgesr8cSSknq1vmTY=
+github.com/zorkian/go-datadog-api v2.21.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 golang.org/x/crypto v0.0.0-20180208170933-5119cf507ed5 h1:YiZSmx39JJyBXrPAMqxSUHrJuQq5qRSFl0u6egWjgCY=
 golang.org/x/crypto v0.0.0-20180208170933-5119cf507ed5/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20180202135801-37707fdb30a5 h1:MF92a0wJ3gzSUVBpjcwdrDr5+klMFRNEEu6Mev4n00I=

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/edvakf/go-pploy/models/datadog"
 	"github.com/edvakf/go-pploy/models/hook"
 	"github.com/edvakf/go-pploy/models/ldapusers"
 	"github.com/edvakf/go-pploy/models/locks"
@@ -27,6 +28,7 @@ func init() {
 	var lockDuration time.Duration
 	var workDir string
 	var sc hook.SlackConfig
+	var dc datadog.DatadogConfig
 	var lc ldapusers.Config
 
 	flag.DurationVar(&lockDuration, "lock", 10*time.Minute, "Duration (ex. 10m) for lock gain")
@@ -41,6 +43,13 @@ func init() {
 	flag.StringVar(&sc.LockReleasedMessage, "lockreleased", "", "Message template for when lock is released")
 	flag.StringVar(&sc.LockExtendedMessage, "lockextended", "", "Message template for when lock is extended")
 	flag.StringVar(&sc.DeployedMessage, "deployed", "", "Message template for when deploy is ended")
+
+	flag.StringVar(&dc.APIKey, "ddapikey", "", "Datadog API key")
+	flag.StringVar(&dc.APPKey, "ddappkey", "", "Datadog APP key")
+	flag.StringVar(&dc.LockGainedMessage, "ddlockgained", "", "Message template for Datadog when lock is gained")
+	flag.StringVar(&dc.LockReleasedMessage, "ddlockreleased", "", "Message template for Datadog when lock is released")
+	flag.StringVar(&dc.LockExtendedMessage, "ddlockextended", "", "Message template for Datadog when lock is extended")
+	flag.StringVar(&dc.DeployedMessage, "dddeployed", "", "Message template for Datadog when deploy is ended")
 
 	flag.StringVar(&lc.Host, "ldaphost", "", "LDAP host (leave empty if ldap is not needed)")
 	flag.IntVar(&lc.Port, "ldapport", 389, "LDAP port")
@@ -70,5 +79,6 @@ func init() {
 	locks.SetDuration(lockDuration)
 	workdir.Init(workDir)
 	hook.SetSlackConfig(sc)
+	datadog.SetDatadogConfig(dc)
 	ldapusers.SetConfig(lc)
 }

--- a/models/datadog/datadog.go
+++ b/models/datadog/datadog.go
@@ -1,0 +1,90 @@
+package datadog
+
+import (
+	"bytes"
+	"crypto/md5"
+	"html/template"
+	"log"
+
+	"github.com/zorkian/go-datadog-api"
+)
+
+// DatadogConfig is a config for Datadog
+type DatadogConfig struct {
+	APIKey              string
+	APPKey              string
+	LockGainedMessage   string
+	LockReleasedMessage string
+	LockExtendedMessage string
+	DeployedMessage     string
+}
+
+var config DatadogConfig
+
+// SetDatadogConfig sets global Datadog config
+func SetDatadogConfig(c DatadogConfig) {
+	config = c
+}
+
+// LockGained sends Datadog when lock is gained
+func LockGained(project, user string) {
+	process(config.LockGainedMessage, project, user, "")
+}
+
+// LockReleased sends Datadog when lock is released
+func LockReleased(project, user string) {
+	process(config.LockReleasedMessage, project, user, "")
+}
+
+// LockExtended sends Datadog when lock is extended
+func LockExtended(project, user string) {
+	process(config.LockExtendedMessage, project, user, "")
+}
+
+// Deployed sends Datadog when a user deployed
+func Deployed(project, user, env string) {
+	process(config.DeployedMessage, project, user, env)
+}
+
+func process(message, project, user, env string) {
+	if config.APIKey == "" || config.APPKey == "" || message == "" {
+		return
+	}
+
+	eventTag := []string{}
+	eventTag = append(eventTag, "project:"+project)
+	if env != "" {
+		eventTag = append(eventTag, "env:"+env)
+	}
+
+	aggregationKey := md5.Sum([]byte(project + user))
+
+	e := datadog.Event{
+		Title:       datadog.String(makeText(message, params{project, user, env})),
+		Aggregation: datadog.String(string(aggregationKey[:])),
+		SourceType:  datadog.String("pploy"),
+		Tags:        eventTag,
+		Url:         datadog.String("www.pixiv.net"),
+		Resource:    datadog.String("pploy"),
+	}
+
+	client := datadog.NewClient(config.APIKey, config.APPKey)
+	go client.PostEvent(&e)
+}
+
+type params struct {
+	Project string
+	User    string
+	Env     string
+}
+
+func makeText(tmpl string, a interface{}) string {
+	var buf bytes.Buffer
+	tp := template.Must(template.New("calculator").Parse(tmpl))
+	err := tp.Execute(&buf, a)
+	if err != nil {
+		log.Println("failed to process template: " + tmpl)
+		return ""
+	}
+	return buf.String()
+}

--- a/models/locks/locks.go
+++ b/models/locks/locks.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edvakf/go-pploy/models/datadog"
 	"github.com/edvakf/go-pploy/models/hook"
 )
 
@@ -54,6 +55,7 @@ func Gain(project string, user string, now time.Time) (*Lock, error) {
 	}
 	l = Lock{User: user, EndTime: now.Add(lockDuration)}
 	locks[project] = l
+	datadog.LockGained(project, user)
 	hook.LockGained(project, user)
 	return &l, nil
 }
@@ -71,6 +73,7 @@ func Extend(project string, user string, now time.Time) (*Lock, error) {
 	// l.EndTime = l.EndTime.Add(lockDuration)
 	l = Lock{User: user, EndTime: l.EndTime.Add(lockDuration)}
 	locks[project] = l
+	datadog.LockExtended(project, user)
 	hook.LockExtended(project, user)
 	return &l, nil
 }
@@ -86,6 +89,7 @@ func Release(project string, user string, now time.Time) error {
 		return errors.New("user does not have lock for the project")
 	}
 	delete(locks, project)
+	datadog.LockReleased(project, user)
 	hook.LockReleased(project, user)
 	return nil
 }

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/edvakf/go-pploy/models/cache"
+	"github.com/edvakf/go-pploy/models/datadog"
 	"github.com/edvakf/go-pploy/models/headreader"
 	"github.com/edvakf/go-pploy/models/hook"
 	"github.com/edvakf/go-pploy/models/locks"
@@ -141,6 +142,7 @@ func (p *Project) Deploy(env string, user string) (io.Reader, error) {
 	}
 	callback := func() {
 		f.Close()
+		datadog.Deployed(p.Name, user, env)
 		hook.Deployed(p.Name, user, env)
 	}
 	r, err := stdoutReader(cmd, callback)


### PR DESCRIPTION
Slackのhookと同様に、DatadogへEventをPostできるようにする。

![スクリーンショット 2019-07-17 15 06 08](https://user-images.githubusercontent.com/6728853/61351144-caadc700-a8a4-11e9-8e3c-acf332b4b131.png)
